### PR TITLE
fix conflict with Editor Word Completion plugin

### DIFF
--- a/source/editor.cpp
+++ b/source/editor.cpp
@@ -301,13 +301,14 @@ static void GetFilePathName (wchar_t* filename, size_t size)
 	Info.EditorControl (-1, ECTL_GETFILENAME, size, filename);
 }
 
-static void EditorProcessKey (wchar_t unicode)
+static void EditorProcessKey (wchar_t unicode, WORD keycode = 0)
 {
 	INPUT_RECORD	tr;
 	tr.EventType = KEY_EVENT;
 	tr.Event.KeyEvent.bKeyDown = true;
 	tr.Event.KeyEvent.wRepeatCount = 1;
-	tr.Event.KeyEvent.wVirtualKeyCode = 0;
+	tr.Event.KeyEvent.wVirtualKeyCode = keycode;
+	tr.Event.KeyEvent.wVirtualScanCode = 0;
 	tr.Event.KeyEvent.uChar.UnicodeChar = unicode;
 	tr.Event.KeyEvent.dwControlKeyState = 0;
 	Info.EditorControl (-1, ECTL_PROCESSINPUT, 0, &tr);

--- a/source/editorinput.cpp
+++ b/source/editorinput.cpp
@@ -473,7 +473,7 @@ intptr_t WINAPI ProcessEditorInputW(const struct ProcessEditorInputInfo *Info)
 				return (PROCESS_EVENT);
 
 			wchar_t	line[MAX_STR_LEN];
-			for (int i = 0; i < MAX_STR_LEN; i++) line[i] = L' ';
+			for (intptr_t i = 0; i < MAX_STR_LEN; i++) line[i] = L' ';
 			line[MAX_STR_LEN - 1] = L'\0';
 
 			TEditorPos	epos = EditorGetPos ();
@@ -521,6 +521,7 @@ intptr_t WINAPI ProcessEditorInputW(const struct ProcessEditorInputInfo *Info)
 
 			bool	inImm = false, inImmExp = false;
 			wchar_t	vChar = Info->Rec.Event.KeyEvent.uChar.UnicodeChar;
+			WORD		keycode = Info->Rec.Event.KeyEvent.wVirtualKeyCode;
 			if (!spORret)
 			{
 				if (lng->ignoreCase)
@@ -561,7 +562,7 @@ intptr_t WINAPI ProcessEditorInputW(const struct ProcessEditorInputInfo *Info)
 					if (!spORret)
 					{
 						pluginBusy = 1;
-						EditorProcessKey (vChar);
+						EditorProcessKey (vChar, keycode);
 						pluginBusy = 0;
 						ret = IGNORE_EVENT;
 						EditorGetStr (&gs);


### PR DESCRIPTION
processing of user input sometimes caused ECompl garble entered text
